### PR TITLE
Fix issues with ALA backend that output invalid KQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ test-merge:
 	tests/test-merge.sh
 	! $(COVERAGE) run -a --include=$(COVSCOPE) tools/merge_sigma tests/not_existing.yml > /dev/null
 
+test-backend-ala:
+	cd tools && python3 setup.py install
+	cd tools && $(COVERAGE) run -m pytest tests/test_backend_ala.py
+
 test-backend-es-qs:
 	tests/test-backend-es-qs.py
 

--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -106,32 +106,40 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
         return parse_arg
 
     def default_value_mapping(self, val):
-        op = "=="
-        if isinstance(val, str):
-            if "*" in val[1:-1]:  # value contains * inside string - use regex match
-                op = "matches regex"
-                val = re.sub('(\\\\\*|\*)', '.*', val)
-                if "\\" in val:
-                    val = "@'(?i)%s'" % (val)
-                else:
-                    val = "'(?i)%s'" % (val)
-                return "%s %s" % (op, self.cleanValue(val))
-            elif val.startswith("*") or val.endswith("*"):
-                if val.startswith("*") and val.endswith("*"):
-                    op = "contains"
-                elif val.startswith("*"):
-                    op = "endswith"
-                elif val.endswith("*"):
-                    op = "startswith"
-                val = re.sub('([".^$]|(?![*?]))', '\g<1>', val)
-                val = re.sub('(\\\\\*|\*)', '.*', val)
-                val = re.sub('\\?', '.', val)
-                if "\\" in val:
-                    return "%s @'%s'" % (op, self.cleanValue(val))
-                return "%s '%s'" % (op, self.cleanValue(val))
-            elif "\\" in val:
-                return "%s @'%s'" % (op, self.cleanValue(val))
-        return "%s \"%s\"" % (op, self.cleanValue(val))
+        try:
+            # Check whether the input is a valid regex. If this raises an error we know we can
+            # treat it as a normal value. Otherwise, we'll assume it's a regex unless it matches
+            # common conditions that shouldn't be regexes.
+            re.compile(val)
+
+            # If the value doesn't contain any special characters it shouldn't need to be a regex
+            if re.match(r'[^\w\s]', val) is None:
+                return self.non_regex_value_mapping(val)
+
+            # `abc*` is a valid regexp but the language spec treats this as `endswith`
+            if re.match(r'.*[^\.]\*$', val) is not None:
+                return self.non_regex_value_mapping(val)
+
+            # TODO: There are probably more scenarios we need to account for here...
+
+            return f'matches regex @"{val}"'
+        except:
+            return self.non_regex_value_mapping(val)
+
+    def non_regex_value_mapping(self, val):
+        op = '=='
+        if val.startswith('*'):
+            if val.endswith('*'):
+                op = 'contains'
+            else:
+                op = 'endswith'
+        elif val.endswith('*'):
+            op = 'startswith'
+
+        val = re.sub(r'(^\*|\*$)', '', val)
+
+        return f'{op} "{val}"'
+
 
     def getTable(self, sigmaparser):
         if self.category == "process_creation" and len(set(sigmaparser.values.keys()) - {"Image", "ParentImage",

--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -89,6 +89,9 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
         else:
             self._field_map = {}
 
+    def cleanValue(self, val):
+        return super().cleanValue(str(val))
+
     def map_sysmon_schema(self, eventid):
         schema_keys = []
         try:
@@ -265,7 +268,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                 elif callable(mapping):
                     return self.generateSubexpressionNode(
                             self.generateANDNode(
-                                [cond for cond in mapping(key, self.cleanValue(str(value)))]
+                                [cond for cond in mapping(key, self.cleanValue(value))]
                                 )
                             )
             elif len(mapping) == 2:
@@ -274,7 +277,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                     if type(mapitem) == str:
                         result.append(mapitem)
                     elif callable(mapitem):
-                        result.append(mapitem(self.cleanValue(str(val))))
+                        result.append(mapitem(self.cleanValue(val)))
                 return "{} {}".format(*result)
             else:
                 raise TypeError("Backend does not support map values of type " + str(type(value)))

--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -236,10 +236,10 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
             return "(" + self.generateORNode(
                     [(key, v) for v in value]
                     ) + ")"
-        elif key == "EventID":            # EventIDs are not reflected in condition but in table selection
+        elif key.lower() in ['eventid', 'event_id']:            # EventIDs are not reflected in condition but in table selection
             if self.service == "sysmon":
                 self.table = "SysmonEvent"
-                self.eventid = value
+                self.eventid = str(value)
             elif self.service == "powershell":
                 self.table = "Event"
             elif self.service == "security":
@@ -265,7 +265,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                 elif callable(mapping):
                     return self.generateSubexpressionNode(
                             self.generateANDNode(
-                                [cond for cond in mapping(key, self.cleanValue(value))]
+                                [cond for cond in mapping(key, self.cleanValue(str(value)))]
                                 )
                             )
             elif len(mapping) == 2:
@@ -274,7 +274,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                     if type(mapitem) == str:
                         result.append(mapitem)
                     elif callable(mapitem):
-                        result.append(mapitem(self.cleanValue(val)))
+                        result.append(mapitem(self.cleanValue(str(val))))
                 return "{} {}".format(*result)
             else:
                 raise TypeError("Backend does not support map values of type " + str(type(value)))

--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -155,7 +155,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
             self.table = "SecurityEvent"
         elif self.service and self.service.lower() == "sysmon":
             self.table = "SysmonEvent"
-        elif self.service and self.service.lower() == "powershell":
+        elif self.service and self.service.lower().startswith("powershell"):
             self.table = "Event"
         elif self.service and self.service.lower() == "office365":
             self.table = "OfficeActivity"

--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -48,7 +48,6 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
     )
     config_required = False
 
-    reEscape = re.compile('(\\\|"|(?<!)(?![*?]))')
     andToken = " and "
     orToken = " or "
     notToken = "not "
@@ -126,7 +125,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
             # TODO: There are probably more scenarios we need to account for here...
 
             return f'matches regex @"{val}"'
-        except:
+        except re.error:
             return self.non_regex_value_mapping(val)
 
     def non_regex_value_mapping(self, val):

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -265,6 +265,7 @@ def main():
                 if not cmdargs.defer_abort:
                     sys.exit(error)
         except (NotImplementedError, TypeError) as e:
+            raise e
             print("An unsupported feature is required for this Sigma rule (%s): " % (sigmafile) + str(e), file=sys.stderr)
             print("Feel free to contribute for fun and fame, this is open source :) -> https://github.com/Neo23x0/sigma", file=sys.stderr)
             if not cmdargs.ignore_backend_errors:

--- a/tools/tests/test_backend_ala.py
+++ b/tools/tests/test_backend_ala.py
@@ -1,0 +1,61 @@
+"""Tests for the Azure Log Analytics backend."""
+
+import pytest
+
+from sigma.backends.ala import AzureLogAnalyticsBackend
+from sigma.configuration import SigmaConfiguration
+
+
+@pytest.fixture()
+def sigmaconfig():
+    """Return a new instance of the sigmaconfig."""
+    with open('../tools/config/ala.yml') as f:
+        return SigmaConfiguration(f)
+
+
+@pytest.fixture()
+def backend(sigmaconfig):
+    """Return a new instance of the backend."""
+    return AzureLogAnalyticsBackend(sigmaconfig)
+
+
+def test_default_value_mapping_simple_contains(backend):
+    """Should return a simple `contains` KQL condition."""
+    val = '*.dll*'
+    result = backend.default_value_mapping(val)
+    assert result == 'contains ".dll"'
+
+
+def test_default_value_mapping_preserve_slashes(backend):
+    """Should preserve slashes in directory paths."""
+    val = "*/.git/*"
+    result = backend.default_value_mapping(val)
+    assert result == 'contains "/.git/"'
+
+
+def test_default_value_mapping_starts_with(backend):
+    """Should return a simple `startswith` KQL condition."""
+    val = 'abc*'
+    result = backend.default_value_mapping(val)
+    assert result == 'startswith "abc"'
+
+
+def test_default_value_mapping_ends_with(backend):
+    """Should return a simple `endswith` KQL condition."""
+    val = '*.env'
+    result = backend.default_value_mapping(val)
+    assert result == 'endswith ".env"'
+
+
+def test_default_value_mapping_regex_prefix(backend):
+    """Should prefix regex strings with `@`."""
+    val = '.*test.*'
+    result = backend.default_value_mapping(val)
+    assert result == 'matches regex @".*test.*"'
+
+
+def test_default_value_mapping_simple_equals(backend):
+    """Should return a simple `==` KQL condition."""
+    val = 'test'
+    result = backend.default_value_mapping(val)
+    assert result == '== "test"'


### PR DESCRIPTION
- Fixes an issue with `startswith`, `endswith`, and `contains` that left `*` characters which are interpreted literally by KQL.
- Adds unit tests for these scenarios
- Fixes an issue where EventID was not matched due to case sensitivity or the use of snake case in the source sigma.
- Fixes an issue where non-string values are coerced to strings for passing to `cleanvalue()`.
